### PR TITLE
enable rpm build for Azure Linux 3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,13 @@ RUN --mount=target=/src,rw make rpm && \
     mkdir /out && \
     cp -r /src/rpmbuild/RPMS/x86_64/*.rpm /out/
 
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 as azl3
+RUN tdnf install -y rpm-build make python3-devel
+WORKDIR /src
+RUN --mount=target=/src,rw make rpm && \
+    mkdir /out && \
+    cp -r /src/rpmbuild/RPMS/x86_64/*.rpm /out/
+
 FROM registry.access.redhat.com/ubi9:latest as el9
 RUN yum install -y rpm-build make python3-devel
 WORKDIR /src
@@ -21,5 +28,6 @@ RUN --mount=target=/src,rw make rpm && \
 
 FROM scratch
 COPY --from=cm2 /out/* /
+COPY --from=azl3 /out/* /
 COPY --from=el8 /out/* /
 COPY --from=el9 /out/* /


### PR DESCRIPTION
Follows the existing pattern in `Dockerfile` to produce an RPM appropriate for Azure Linux 3.0.

To validate this, I manually ran `docker buildx build --output ...` locally and successfully produced the RPMs. I installed the `.azl3` RPM in an Azure Linux 3.0 WSL environment and confirmed that it functioned as expected to access a repo backed by authenticated Azure blob storage.

_(I debated adding a changelog entry in the `.spec`, following the pattern of previous changes, but there weren't actually any changes to the packaged component -- it's just building for another distro/version. But, of course, please let me know if you'd prefer otherwise.)_